### PR TITLE
Don't let `yargs` default handle the `--help` and `--version` arguments

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -18,7 +18,7 @@ const CONFIG_FILES = [
 export default async function lookup(cwd = process.cwd()) {
 
 	// Check if a loader was specified explicitly.
-	let parsed = yargs(hideBin(process.argv));
+	let parsed = yargs(hideBin(process.argv)).help(false).version(false);
 	let config = parsed.argv['loader-config'];
 	let fullPath;
 	if (config) {


### PR DESCRIPTION
Don't let `yargs` default handle the `--help` and `--version` arguments,
so that any command-line script using `node-esm-loader` can use them instead.

With this change, `node-esm-loader` will very strictly only handle the `--loader-config` arg, nothing else.
