### PR TITLE
fix: use initialize hook for custom loader config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [18.19, 20.6]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -5,21 +5,8 @@
 **DISCLAIMER** Loaders [are still experimental](https://nodejs.org/api/esm.html#esm_experimental_loaders) in Node and may still change, which means this module is still experimental as well.
 Use at own risk and **DO NOT** rely on it in production.
 
-Node 14 provides full support for native ES Modules without the need for transpilation.
-While CommonJS is likely not to go anywhere soon, it is good practice to at least start thinking about migrating your codebase from CommonJS to ESM.
-In the `require`-world, we had [require.extensions](https://nodejs.org/api/modules.html#modules_require_extensions) if we wanted to load non-JS files into Node.
-You could use this, for example, to load TypeScript files and compile them just-in-time.
-While this was not a good idea in production, it was a nice to have in development.
-For example, you could run tests without having to transpile them first.
-
-In the ESM world we no longer have `require.extensions`, but Node provides us with [loader hooks](https://nodejs.org/api/esm.html#esm_experimental_loaders) which can be used to provide the same functionality, and even more.
-The goal of this module is to make it easier to write such loaders, especially when composing loaders.
-It is **strongly disadvised** to use this module in production.
-The aim is not to eliminate the necessity of a build step, but to make your life easier **during development**.
-
 This module is a simple wrapper around [create-esm-loader](https://www.npmjs.com/package/create-esm-loader) to make it easier to set up a loader.
 In [create-esm-loader](https://www.npmjs.com/package/create-esm-loader) you have to manually initialize, configure and export your loader, but this module reduces that so that all you need to do is *configure* the loader.
-This will - hopefully - eliminate the need to reconfigure your loaders when the Node loader api changes.
 
 ## Installation
 
@@ -30,18 +17,25 @@ This will - hopefully - eliminate the need to reconfigure your loaders when the 
 `node-esm-loader` will automatically export a loader based on how you configured it.
 You can use it by running Node as
 ```
-node --experimental-loader=node-esm-loader ./your/file.js
-```
-On Node `>=20.7` however, [it is discouraged](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--experimental-loadermodule) to use the `--experimental-loader` flag and instead the `--import` flag should be used in combination with `register()` from `node:module`
-```js
-import { register } from 'node:module';
-register('node-esm-loader', import.meta.url);
-```
-or make it easy on yourself and just use
-```sh
-# Preferred pattern on Node >=20.7
 node --import=node-esm-loader/register ./your/file.js
 ```
+
+Or you can use the JavaScript api
+```js
+// # register.js
+import { register } from 'node:module';
+register('node-esm-loader', import.meta.url, {
+
+  // Optional, will use the default .loaderrc.js config file if present
+  loaderConfig: './path/to/config.js',
+
+});
+```
+and then run Node as
+```
+node --import=./register.js ./your/file.js
+```
+For more info about this, see https://nodejs.org/api/module.html#customization-hooks
 
 `node-esm-loader` loader will subsequently look for a `.loaderrc.mjs` or `.loaderrc.js` file that exports the configuration.
 This file can look something like this:
@@ -62,22 +56,15 @@ export default {
 };
 ```
 
-Alternatively you can run node with an additional flag that specifies the path to your loader configuration
-```sh
-node --experimental-loader=node-esm-loader ./your/file.js --loader-config=./path/to/config.js
-
-# On Node >=20.7
-node --import=node-esm-loader/register ./your/file.js --loader-config=./path/to/config.js
+If you want to store the loader config in a different file, you can use
+```
+node --import=node-esm-loader/register ./your-file.js --loader-config=./path/to/config.js
 ```
 
 When using this with mocha, create a `.mocharc.cjs` file that looks like this:
 ```js
 module.exports = {
-  'experimental-loader': 'node-esm-loader',
-
-  // On Node 20.7
   import: 'node-esm-loader/register',
-
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ import { register } from 'node:module';
 register('node-esm-loader', import.meta.url, {
 
   // Optional, will use the default .loaderrc.js config file if present
-  loaderConfig: './path/to/config.js',
+  data: {
+    loaderConfig: './path/to/config.js',
+  },
 
 });
 ```

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,11 +1,27 @@
 import create from 'create-esm-loader';
 import lookup from './lookup.js';
 
-const config = await lookup();
-export const {
-	resolve,
-	getFormat,
-	getSource,
-	transformSource,
-	load,
-} = await create(config);
+// See #5. We now create the hooks just in time in the initialize hook so that 
+// the main process can inject a loader config.
+let hooks;
+export async function initialize(opts = {}) {
+	let config = await lookup(opts);
+	hooks = await create(config);
+}
+
+// See #5. The loader doesn't wait for the initialize hook to have finished, 
+// which means the resolve and load hooks are used *immediately*. This means 
+// that if the hooks haven't fully loaded yet, we just use Node's default 
+// resolution & load hooks.
+export async function resolve(specifier, ctx, nextResolve) {
+	if (hooks) {
+		return hooks.resolve(specifier, ctx, nextResolve);
+	}
+	return nextResolve(specifier);
+}
+export async function load(specifier, ctx, nextLoad) {
+	if (hooks) {
+		return hooks.load(specifier, ctx, nextLoad);
+	}
+	return nextLoad(specifier);
+}

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -4,8 +4,6 @@
 import { pathToFileURL } from 'node:url';
 import path from 'node:path';
 import findUp from 'find-up';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
 
 // The supported config files we look for, in that order.
 const CONFIG_FILES = [
@@ -15,15 +13,13 @@ const CONFIG_FILES = [
 
 // Finds and loads the configuration file based on the parameters the process 
 // was run with.
-export default async function lookup(cwd = process.cwd()) {
+export default async function lookup({ loaderConfig, cwd = process.cwd() }) {
 
 	// Check if a loader was specified explicitly.
-	let parsed = yargs(hideBin(process.argv)).help(false).version(false);
-	let config = parsed.argv['loader-config'];
-	if (!config) config = process.env.LOADER_CONFIG;
+	if (!loaderConfig) loaderConfig = process.env.LOADER_CONFIG;
 	let fullPath;
-	if (config) {
-		fullPath = path.resolve(process.cwd(), config);
+	if (loaderConfig) {
+		fullPath = path.resolve(process.cwd(), loaderConfig);
 	} else {
 		fullPath = findConfig(cwd);
 	}

--- a/lib/parse-argv.js
+++ b/lib/parse-argv.js
@@ -1,0 +1,6 @@
+// # parse-args.js
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const parsed = yargs(hideBin(process.argv)).help(false).version(false);
+export const { loaderConfig } = parsed.argv;

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,15 +1,9 @@
 import { register } from 'node:module';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
-
-// On Node 20 the arguments are no longer passed to the loader thread, but 
-// environment variables are, so if a file was specified, we transfer it using 
-// the LOADER_CONFIG environment variable.
-const parsed = yargs(hideBin(process.argv)).help(false).version(false);
-const config = parsed.argv['loader-config'];
-if (config) {
-	process.env.LOADER_CONFIG = config;
-}
+import { loaderConfig } from './parse-argv.js';
 
 // Register.
-register('./loader.js', import.meta.url);
+register('./loader.js', import.meta.url, {
+	data: {
+		loaderConfig,
+	},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,12 @@
         "yargs": "^17.2.1"
       },
       "devDependencies": {
+        "@vue/component-compiler-utils": "^3.3.0",
         "chai": "^4.3.4",
         "mocha": "^10.2.0",
         "semver": "^7.5.4",
         "vue": "^2.6.14",
-        "vue-esm-loader": "0.0.2",
+        "vue-esm-loader": "^0.2.2",
         "vue-template-compiler": "^2.6.14"
       }
     },
@@ -44,7 +45,7 @@
     "node_modules/@vue/component-compiler-utils/node_modules/hash-sum": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+      "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -283,6 +284,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
       "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+      "deprecated": "Please upgrade to consolidate v1.0.0+ as it has been modernized with several long-awaited fixes implemented. Maintenance is supported by Forward Email at https://forwardemail.net ; follow/watch https://github.com/ladjs/consolidate for updates and release changelog",
       "dev": true,
       "dependencies": {
         "bluebird": "^3.1.1"
@@ -292,9 +294,9 @@
       }
     },
     "node_modules/create-esm-loader": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.2.4.tgz",
-      "integrity": "sha512-COjlrIKjDjMy1NGpZCn69wYxwMuA/YCfe94YYoO+4nGuDm2Q3V1Q3yo/FzJtgdSAsjuA7E8yoVGU5UdcTSj5+w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.2.5.tgz",
+      "integrity": "sha512-WSg6l2sre6yVp0C4HYzYSJUn6H5tp7av6ZkGyiIKayR+xBqEYPrtxL+LAz8f+wD2VJs7/PDlK+SokaMkCxIGpw==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -466,9 +468,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -896,9 +898,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -909,9 +911,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -919,12 +921,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -1099,7 +1104,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/vue": {
@@ -1109,29 +1114,13 @@
       "dev": true
     },
     "node_modules/vue-esm-loader": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/vue-esm-loader/-/vue-esm-loader-0.0.2.tgz",
-      "integrity": "sha512-ms/plWoaIFXS7KrAnmkJGT0xDEyAr0TVyUvpSMue6rjL/N7r3DcKXkrYvqh+Mmuga8r3yjeERxIZ+jZzOVH9gA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vue-esm-loader/-/vue-esm-loader-0.2.2.tgz",
+      "integrity": "sha512-qfhroh2uRVSFOJTfm4LUcXB81MgbwyHSxwGXHHNeFqRIM3PR3EpYqu/bcVk4uMHTnosUC4LXbKMcvVkt0azetg==",
       "dev": true,
       "dependencies": {
-        "@vue/component-compiler-utils": "^3.2.0",
-        "create-esm-loader": "^0.1.0",
+        "create-esm-loader": "^0.2.5",
         "hash-sum": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.x"
-      },
-      "peerDependencies": {
-        "vue-template-compiler": "2.x"
-      }
-    },
-    "node_modules/vue-esm-loader/node_modules/create-esm-loader": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.1.2.tgz",
-      "integrity": "sha512-5AVD7/0UOtO7uMDpkvY7Lo5KeBQ7auOLg/vXfHqiDCGqE1cvMWvHl/h9NOMphh7Pgei5/w9czkOh4Ysx03260A==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14.x"
@@ -1192,7 +1181,7 @@
     "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
     "node_modules/yargs": {
@@ -1268,7 +1257,7 @@
         "hash-sum": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-          "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+          "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
           "dev": true
         }
       }
@@ -1458,9 +1447,9 @@
       }
     },
     "create-esm-loader": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.2.4.tgz",
-      "integrity": "sha512-COjlrIKjDjMy1NGpZCn69wYxwMuA/YCfe94YYoO+4nGuDm2Q3V1Q3yo/FzJtgdSAsjuA7E8yoVGU5UdcTSj5+w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.2.5.tgz",
+      "integrity": "sha512-WSg6l2sre6yVp0C4HYzYSJUn6H5tp7av6ZkGyiIKayR+xBqEYPrtxL+LAz8f+wD2VJs7/PDlK+SokaMkCxIGpw==",
       "requires": {
         "semver": "^7.3.5"
       }
@@ -1574,9 +1563,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
     },
     "glob": {
@@ -1888,9 +1877,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -1898,16 +1887,16 @@
       }
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "optional": true
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "randombytes": {
@@ -2028,7 +2017,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "vue": {
@@ -2038,25 +2027,13 @@
       "dev": true
     },
     "vue-esm-loader": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/vue-esm-loader/-/vue-esm-loader-0.0.2.tgz",
-      "integrity": "sha512-ms/plWoaIFXS7KrAnmkJGT0xDEyAr0TVyUvpSMue6rjL/N7r3DcKXkrYvqh+Mmuga8r3yjeERxIZ+jZzOVH9gA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vue-esm-loader/-/vue-esm-loader-0.2.2.tgz",
+      "integrity": "sha512-qfhroh2uRVSFOJTfm4LUcXB81MgbwyHSxwGXHHNeFqRIM3PR3EpYqu/bcVk4uMHTnosUC4LXbKMcvVkt0azetg==",
       "dev": true,
       "requires": {
-        "@vue/component-compiler-utils": "^3.2.0",
-        "create-esm-loader": "^0.1.0",
+        "create-esm-loader": "^0.2.5",
         "hash-sum": "^2.0.0"
-      },
-      "dependencies": {
-        "create-esm-loader": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/create-esm-loader/-/create-esm-loader-0.1.2.tgz",
-          "integrity": "sha512-5AVD7/0UOtO7uMDpkvY7Lo5KeBQ7auOLg/vXfHqiDCGqE1cvMWvHl/h9NOMphh7Pgei5/w9czkOh4Ysx03260A==",
-          "dev": true,
-          "requires": {
-            "semver": "^7.3.5"
-          }
-        }
       }
     },
     "vue-template-compiler": {
@@ -2105,7 +2082,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,129 @@
         "chai": "^4.3.4",
         "mocha": "^10.2.0",
         "semver": "^7.5.4",
-        "vue": "^2.6.14",
+        "vue": "^3.3.11",
         "vue-esm-loader": "^0.2.2",
         "vue-template-compiler": "^2.6.14"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.11.tgz",
+      "integrity": "sha512-h97/TGWBilnLuRaj58sxNrsUU66fwdRKLOLQ9N/5iNDfp+DZhYH9Obhe0bXxhedl8fjAgpRANpiZfbgWyruQ0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.11.tgz",
+      "integrity": "sha512-zoAiUIqSKqAJ81WhfPXYmFGwDRuO+loqLxvXmfUdR5fOitPoUiIeFI9cTTyv9MU5O1+ZZglJVTusWzy+wfk5hw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.11.tgz",
+      "integrity": "sha512-U4iqPlHO0KQeK1mrsxCN0vZzw43/lL8POxgpzcJweopmqtoYy9nljJzWDIQS3EfjiYhfdtdk9Gtgz7MRXnz3GA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.11",
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/compiler-ssr": "3.3.11",
+        "@vue/reactivity-transform": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.11.tgz",
+      "integrity": "sha512-Zd66ZwMvndxRTgVPdo+muV4Rv9n9DwQ4SSgWWKWkPFebHQfVYRrVjeygmmDmPewsHyznCNvJ2P2d6iOOhdv8Qg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/shared": "3.3.11"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -46,6 +166,68 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
       "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+      "dev": true
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.11.tgz",
+      "integrity": "sha512-D5tcw091f0nuu+hXq5XANofD0OXnBmaRqMYl5B3fCR+mX+cXJIGNw/VNawBqkjLNWETrFW0i+xH9NvDbTPVh7g==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.11.tgz",
+      "integrity": "sha512-fPGjH0wqJo68A0wQ1k158utDq/cRyZNlFoxGwNScE28aUFOKFEnCBsvyD8jHn+0kd0UKVpuGuaZEQ6r9FJRqCg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.11.tgz",
+      "integrity": "sha512-g9ztHGwEbS5RyWaOpXuyIVFTschclnwhqEbdy5AwGhYOgc7m/q3NFwr50MirZwTTzX55JY8pSkeib9BX04NIpw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.11.tgz",
+      "integrity": "sha512-OlhtV1PVpbgk+I2zl+Y5rQtDNcCDs12rsRg71XwaA2/Rbllw6mBLMi57VOn8G0AjOJ4Mdb4k56V37+g8ukShpQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.11.tgz",
+      "integrity": "sha512-AIWk0VwwxCAm4wqtJyxBylRTXSy1wCLOKbWxHaHiu14wjsNYtiRCSgVuqEPVuDpErOlRdNnuRgipQfXRLjLN5A==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.11",
+        "@vue/shared": "3.3.11"
+      },
+      "peerDependencies": {
+        "vue": "3.3.11"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.11.tgz",
+      "integrity": "sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -316,6 +498,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -402,6 +590,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -691,6 +885,18 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/merge-source-map": {
@@ -1029,6 +1235,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1108,10 +1323,25 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
-      "dev": true
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.11.tgz",
+      "integrity": "sha512-d4oBctG92CRO1cQfVBZp6WJAs0n8AK4Xf5fNjQCBeKCvMI1efGQ5E3Alt1slFJS9fZuPcFoiAiqFvQlv1X7t/w==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/compiler-sfc": "3.3.11",
+        "@vue/runtime-dom": "3.3.11",
+        "@vue/server-renderer": "3.3.11",
+        "@vue/shared": "3.3.11"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vue-esm-loader": {
       "version": "0.2.2",
@@ -1237,6 +1467,93 @@
     }
   },
   "dependencies": {
+    "@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@vue/compiler-core": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.11.tgz",
+      "integrity": "sha512-h97/TGWBilnLuRaj58sxNrsUU66fwdRKLOLQ9N/5iNDfp+DZhYH9Obhe0bXxhedl8fjAgpRANpiZfbgWyruQ0w==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.11.tgz",
+      "integrity": "sha512-zoAiUIqSKqAJ81WhfPXYmFGwDRuO+loqLxvXmfUdR5fOitPoUiIeFI9cTTyv9MU5O1+ZZglJVTusWzy+wfk5hw==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-core": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.11.tgz",
+      "integrity": "sha512-U4iqPlHO0KQeK1mrsxCN0vZzw43/lL8POxgpzcJweopmqtoYy9nljJzWDIQS3EfjiYhfdtdk9Gtgz7MRXnz3GA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.11",
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/compiler-ssr": "3.3.11",
+        "@vue/reactivity-transform": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
+        "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "8.4.32",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+          "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+          "dev": true,
+          "requires": {
+            "nanoid": "^3.3.7",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        }
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.11.tgz",
+      "integrity": "sha512-Zd66ZwMvndxRTgVPdo+muV4Rv9n9DwQ4SSgWWKWkPFebHQfVYRrVjeygmmDmPewsHyznCNvJ2P2d6iOOhdv8Qg==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
     "@vue/component-compiler-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.3.0.tgz",
@@ -1261,6 +1578,65 @@
           "dev": true
         }
       }
+    },
+    "@vue/reactivity": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.11.tgz",
+      "integrity": "sha512-D5tcw091f0nuu+hXq5XANofD0OXnBmaRqMYl5B3fCR+mX+cXJIGNw/VNawBqkjLNWETrFW0i+xH9NvDbTPVh7g==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.11.tgz",
+      "integrity": "sha512-fPGjH0wqJo68A0wQ1k158utDq/cRyZNlFoxGwNScE28aUFOKFEnCBsvyD8jHn+0kd0UKVpuGuaZEQ6r9FJRqCg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.11.tgz",
+      "integrity": "sha512-g9ztHGwEbS5RyWaOpXuyIVFTschclnwhqEbdy5AwGhYOgc7m/q3NFwr50MirZwTTzX55JY8pSkeib9BX04NIpw==",
+      "dev": true,
+      "requires": {
+        "@vue/reactivity": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.11.tgz",
+      "integrity": "sha512-OlhtV1PVpbgk+I2zl+Y5rQtDNcCDs12rsRg71XwaA2/Rbllw6mBLMi57VOn8G0AjOJ4Mdb4k56V37+g8ukShpQ==",
+      "dev": true,
+      "requires": {
+        "@vue/runtime-core": "3.3.11",
+        "@vue/shared": "3.3.11",
+        "csstype": "^3.1.2"
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.11.tgz",
+      "integrity": "sha512-AIWk0VwwxCAm4wqtJyxBylRTXSy1wCLOKbWxHaHiu14wjsNYtiRCSgVuqEPVuDpErOlRdNnuRgipQfXRLjLN5A==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-ssr": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.11.tgz",
+      "integrity": "sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==",
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -1460,6 +1836,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -1518,6 +1900,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "fill-range": {
@@ -1728,6 +2116,15 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "merge-source-map": {
@@ -1966,6 +2363,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2021,10 +2424,17 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
-      "dev": true
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.11.tgz",
+      "integrity": "sha512-d4oBctG92CRO1cQfVBZp6WJAs0n8AK4Xf5fNjQCBeKCvMI1efGQ5E3Alt1slFJS9fZuPcFoiAiqFvQlv1X7t/w==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.3.11",
+        "@vue/compiler-sfc": "3.3.11",
+        "@vue/runtime-dom": "3.3.11",
+        "@vue/server-renderer": "3.3.11",
+        "@vue/shared": "3.3.11"
+      }
     },
     "vue-esm-loader": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "yargs": "^17.2.1"
   },
   "devDependencies": {
+    "@vue/component-compiler-utils": "^3.3.0",
     "chai": "^4.3.4",
     "mocha": "^10.2.0",
     "semver": "^7.5.4",
     "vue": "^2.6.14",
-    "vue-esm-loader": "0.0.2",
+    "vue-esm-loader": "^0.2.2",
     "vue-template-compiler": "^2.6.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.3.4",
     "mocha": "^10.2.0",
     "semver": "^7.5.4",
-    "vue": "^2.6.14",
+    "vue": "^3.3.11",
     "vue-esm-loader": "^0.2.2",
     "vue-template-compiler": "^2.6.14"
   }

--- a/test/run.js
+++ b/test/run.js
@@ -2,15 +2,9 @@ import cp from 'node:child_process';
 import semver from 'semver';
 
 export default function run(file, args = [], opts = {}) {
-	let flag = (
-		semver.satisfies(process.version, '>=20.6') ?
-		'--import=node-esm-loader/register' :
-		'--experimental-loader=node-esm-loader'
-	);
 	const child = cp.fork(file, args, {
 		execArgv: [
-			flag,
-			'--no-warnings',
+			'--import=node-esm-loader/register',
 		],
 		...opts,
 	})


### PR DESCRIPTION
This PR fixes #5 by leveraging the `initialize()` hook to inject a custom loader config file with the `--loader-config`. This feature was broken on Node 20.6 because the loaders now run in a separate thread.

Since the loaders api has now pretty much stabilized and has settled on using `import { register } from 'node:module'`, we've dropped support for `--experimental-loader`.

BREAKING CHANGE: Requires Node `>=18.19` or `>=20.6` and drops support for `--experimental-loader`. Use `--import` with `node-esm-loader/register` instead.