### PR TITLE
chore: automatically publish to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: Node.js package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm whoami; npm --ignore-scripts publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ and then run Node as
 ```
 node --import=./register.js ./your/file.js
 ```
-For more info about this, see https://nodejs.org/api/module.html#customization-hooks
+For more info about this, see https://nodejs.org/api/module.html#customization-hooks.
+Note: since version 0.3.0, either Node >=18.19 or >=20.6 is required.
+Support for lower Node version has been dropped.
 
 `node-esm-loader` loader will subsequently look for a configuration file in various places using [cosmiconfig](https://www.npmjs.com/package/cosmiconfig), where it also looks up the directory tree.
 My advice is to either use `.loaderrc.js`, or use a `.config` folder with `.config/loaderrc.js`, but `loader.config.js` will also work.


### PR DESCRIPTION
Added a GitHub action for automatically publishing to npm upon release. We've also updated the readme to reflect that Node >=18.19 or >= 20.6 is now required.